### PR TITLE
Update deprecated `.undent` method

### DIFF
--- a/Formula/dinghy.rb
+++ b/Formula/dinghy.rb
@@ -15,7 +15,7 @@ class Dinghy < Formula
     prefix.install "cli"
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     Run `dinghy create` to create the VM, then `dinghy up` to bring up the VM and services.
     EOS
   end


### PR DESCRIPTION
I noticed this deprecated function while attempting to get a list of my installed brew and cask apps via `brew bundle dump`.

Remove `.undent` in favor of the squiggly heredoc, a native Ruby
function since 2.3.