### PR TITLE
Use UNFS3 branch higher-resolution-setattr for nanoseconds

### DIFF
--- a/Formula/dinghy.rb
+++ b/Formula/dinghy.rb
@@ -4,6 +4,9 @@ class Dinghy < Formula
   url "https://github.com/codekitchen/dinghy.git", :tag => "v4.6.3", :revision => "05349a35ee9858dce3497ce0b90eb5f2dbb1bca8"
   head "https://github.com/codekitchen/dinghy.git", :branch => :master
 
+  # Dinghy version hasn't changed, but unfs3 dependency has
+  revision 1
+
   depends_on "codekitchen/dinghy/unfs3"
 
   def install

--- a/Formula/unfs3.rb
+++ b/Formula/unfs3.rb
@@ -1,15 +1,19 @@
 class Unfs3 < Formula
   desc "User-space NFSv3 server"
   homepage "https://unfs3.sourceforge.io"
-  url "https://downloads.sourceforge.net/project/unfs3/unfs3/0.9.22/unfs3-0.9.22.tar.gz"
-  sha256 "482222cae541172c155cd5dc9c2199763a6454b0c5c0619102d8143bb19fdf1c"
 
+  # Temporarily using Karl Mikaelsson's branch for nanosecond timestamps
+  # on Mac OS High Sierra until such time as he makes an official release.
+  # See: https://github.com/codekitchen/dinghy/issues/269#issuecomment-391007703
+  url "https://github.com/derfian/unfs3.git", :branch => "higher-resolution-setattr"
+  version "0.9.23-pre"
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+
+  # Temporarily keeping 0.9.22 release as 'devel' to ease switching back to test
   devel do
-    url "https://github.com/derfian/unfs3.git", :branch => "higher-resolution-setattr"
-    version "0.9.23-pre"
-
-    depends_on "autoconf" => :build
-    depends_on "automake" => :build
+    url "https://downloads.sourceforge.net/project/unfs3/unfs3/0.9.22/unfs3-0.9.22.tar.gz"
+    sha256 "482222cae541172c155cd5dc9c2199763a6454b0c5c0619102d8143bb19fdf1c"
   end
 
   head do
@@ -21,7 +25,7 @@ class Unfs3 < Formula
 
   def install
     ENV.deparallelize # Build is not parallel-safe
-    system "./bootstrap" if build.head? || build.devel?
+    system "./bootstrap"
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
     system "make"

--- a/Formula/unfs3.rb
+++ b/Formula/unfs3.rb
@@ -1,6 +1,6 @@
 class Unfs3 < Formula
   desc "User-space NFSv3 server"
-  homepage "http://unfs3.sourceforge.net"
+  homepage "https://unfs3.sourceforge.io"
   url "https://downloads.sourceforge.net/project/unfs3/unfs3/0.9.22/unfs3-0.9.22.tar.gz"
   sha256 "482222cae541172c155cd5dc9c2199763a6454b0c5c0619102d8143bb19fdf1c"
 

--- a/Formula/unfs3.rb
+++ b/Formula/unfs3.rb
@@ -4,6 +4,14 @@ class Unfs3 < Formula
   url "https://downloads.sourceforge.net/project/unfs3/unfs3/0.9.22/unfs3-0.9.22.tar.gz"
   sha256 "482222cae541172c155cd5dc9c2199763a6454b0c5c0619102d8143bb19fdf1c"
 
+  devel do
+    url "https://github.com/derfian/unfs3.git", :branch => "higher-resolution-setattr"
+    version "0.9.23-pre"
+
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+  end
+
   head do
     url "http://svn.code.sf.net/p/unfs3/code/trunk/"
 
@@ -13,7 +21,7 @@ class Unfs3 < Formula
 
   def install
     ENV.deparallelize # Build is not parallel-safe
-    system "./bootstrap" if build.head?
+    system "./bootstrap" if build.head? || build.devel?
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
     system "make"


### PR DESCRIPTION
Temporarily switch to using Karl Mikaelsson's branch of UNFS3 to support
nanosecond timestamps in Dinghy on Mac OS High Sierra.

For background, please see:
  - https://github.com/codekitchen/dinghy/issues/269#issuecomment-391007703
  - https://sourceforge.net/p/unfs3/bugs/10/#5c51/c348/ea75/9bb8

If and when an official release of UNFS3 is made containing the nanoseconds
support, we should plan to switch back to using that release.