### PR TITLE
Use 'head' instead of 'devel'

### DIFF
--- a/Formula/unfs3.rb
+++ b/Formula/unfs3.rb
@@ -11,7 +11,7 @@ class Unfs3 < Formula
   depends_on "automake"
 
   # Temporarily keeping 0.9.22 release as 'devel' to ease switching back to test
-  devel do
+  head do
     url "https://downloads.sourceforge.net/project/unfs3/unfs3/0.9.22/unfs3-0.9.22.tar.gz"
     sha256 "482222cae541172c155cd5dc9c2199763a6454b0c5c0619102d8143bb19fdf1c"
   end


### PR DESCRIPTION
Calling 'devel' blocks in formulae is deprecated! Use 'head' blocks or @-versioned formulae instead.

Closes #4 